### PR TITLE
Abstract requests lib to a function

### DIFF
--- a/worker/worker/http_client.py
+++ b/worker/worker/http_client.py
@@ -1,0 +1,32 @@
+from typing import Optional
+
+from worker import log
+from worker.redis_interface import session
+
+
+class HTTPBadStatusCodeError(RuntimeError):
+    def __init__(self, code: int):
+        super().__init__(f'bad http status code {code}')
+
+
+def http_get(url: str) -> Optional[str]:
+    """
+    Retrieves the HTML from a page via HTTP(s).
+
+    If the page is present on the server (200 status code), returns the html.
+    If the server does not host this page (404 status code), returns None.
+    Any other HTTP code are considered as unexpected and raise an HTTPBadStatusCodeError.
+    :param url: url to the page
+    :return: HTML of the page or None
+    """
+    r = session.get(url)
+
+    if r.status_code == 200:
+        # log.debug(f'http_get_success', status_code=r.status_code, url=url)
+        return r.content
+
+    if r.status_code == 404:
+        log.info(f'http_get_error', status_code=r.status_code, url=url)
+        return None
+
+    raise HTTPBadStatusCodeError(r.status_code)

--- a/worker/worker/redis_interface/challenges.py
+++ b/worker/worker/redis_interface/challenges.py
@@ -3,21 +3,22 @@ from multiprocessing.pool import ThreadPool
 
 from worker import log
 from worker.constants import URL
+from worker.http_client import http_get
 from worker.parser.category import extract_categories, extract_category_logo, extract_category_description, \
     extract_category_prereq, extract_challenges_info
-from worker.redis_interface import session, redis_app
+from worker.redis_interface import redis_app
 
 
 def retrieve_category_info(category):
-    r = session.get(f'{URL}fr/Challenges/{category}/')
-    if r.status_code != 200:
-        log.warning(f'HTTP {r.status_code} for category {category}.')
-        return
+    html = http_get(f'{URL}fr/Challenges/{category}/')
+    if html is None:
+        log.warn('category_not_found', category=category)
+        return None
 
-    logo = extract_category_logo(r.content)
-    desc1, desc2 = extract_category_description(r.content)
-    prereq = extract_category_prereq(r.content)
-    challenges = extract_challenges_info(r.content)
+    logo = extract_category_logo(html)
+    desc1, desc2 = extract_category_description(html)
+    prereq = extract_category_prereq(html)
+    challenges = extract_challenges_info(html)
 
     log.msg(f"Fetched category page '{category}'")
 
@@ -33,12 +34,14 @@ def retrieve_category_info(category):
 
 
 def set_all_challenges():
-    r = session.get(URL + 'fr/Challenges/')
-    if r.status_code != 200:
-        log.warning(f'HTTP {r.status_code} for challenges.')
+    html = http_get(URL + 'fr/Challenges/')
+    if html is None:
+        log.error('challenges_page_not_found')
         return
 
-    categories = extract_categories(r.content)
+    categories = extract_categories(html)
+    log.debug('fetched_categories', categories=categories)
+
     with ThreadPool(len(categories)) as tp:
         response = tp.map(retrieve_category_info, categories)
     redis_app.set('challenges', json.dumps(response))

--- a/worker/worker/redis_interface/contributions.py
+++ b/worker/worker/redis_interface/contributions.py
@@ -1,30 +1,32 @@
-from functools import partial
 import itertools
 import json
+from functools import partial
+from multiprocessing.pool import ThreadPool
+
 from worker import log
 from worker.constants import URL
+from worker.http_client import http_get
 from worker.parser.contributions import extract_challenges_contributions, extract_solutions_contributions, \
     extract_contributions_page_numbers
 from worker.redis_interface import session, redis_app
-from multiprocessing.pool import ThreadPool
 
 
 def get_challenge_contributions(username, page_index):
     url = f'{URL}{username}?inc=contributions&debut_challenges_auteur={5 * page_index}#pagination_challenges_auteur'
-    r = session.get(url)
-    if r.status_code != 200:
-        log.warning(f'HTTP {r.status_code} for username {username}.')
+    html = http_get(url)
+    if html is None:
+        log.warning(f'could_not_get_challenge_contributions', username=username, page_index=page_index)
         return
-    return extract_challenges_contributions(r.content)
+    return extract_challenges_contributions(html)
 
 
 def get_solution_contributions(username, page_index):
     url = f'{URL}{username}?inc=contributions&debut_solutions_auteur={5 * page_index}#pagination_solutions_auteur'
-    r = session.get(url)
-    if r.status_code != 200:
-        log.warning(f'HTTP {r.status_code} for username {username}.')
+    html = http_get(url)
+    if html is None:
+        log.warning(f'could_not_get_solution_contributions', username=username, page_index=page_index)
         return
-    return extract_solutions_contributions(r.content)
+    return extract_solutions_contributions(html)
 
 
 def format_contributions_challenges(username, nb_challenges_pages):
@@ -54,12 +56,12 @@ def format_contributions_solutions(username, nb_solutions_pages):
 
 
 def set_user_contributions(username):
-    r = session.get(URL + username + '?inc=contributions')
-    if r.status_code != 200:
-        log.warning(f'HTTP {r.status_code} for username {username}.')
+    html = http_get(URL + username + '?inc=contributions')
+    if html is None:
+        log.warning('could_not_get_user_contributions', username=username)
         return
 
-    nb_challenges_pages, nb_solutions_pages = extract_contributions_page_numbers(r.content)
+    nb_challenges_pages, nb_solutions_pages = extract_contributions_page_numbers(html)
     if nb_challenges_pages == 0 and nb_solutions_pages == 0:
         return  # no challenges or solutions published by this user
 

--- a/worker/worker/redis_interface/ctf.py
+++ b/worker/worker/redis_interface/ctf.py
@@ -3,6 +3,7 @@ import itertools
 import json
 from worker import log
 from worker.constants import URL
+from worker.http_client import http_get
 from worker.parser.ctf import is_not_participating, extract_summary, extract_ctf
 from worker.parser.profile import extract_pseudo
 from worker.redis_interface import session, redis_app
@@ -11,25 +12,26 @@ from multiprocessing.pool import ThreadPool
 
 def get_ctf_page(username, page_index):
     url = f'{URL}{username}?inc=ctf&debut_ctf_alltheday_vm_dispo={50 * page_index}#pagination_ctf_alltheday_vm_dispo'
-    r = session.get(url)
-    if r.status_code != 200:
-        log.warning(f'HTTP {r.status_code} for username {username}.')
+    html = http_get(url)
+    if html is None:
+        log.warning(f'ctf_page_not_found', username=username, page_index=page_index)
         return
-    return extract_ctf(r.content)
+
+    return extract_ctf(html)
 
 
 def set_user_ctf(username):
-    r = session.get(URL + username + '?inc=ctf')
-    if r.status_code != 200:
-        log.warning(f'HTTP {r.status_code} for username {username}.')
+    html = http_get(URL + username + '?inc=ctf')
+    if html is None:
+        log.warning(f'ctf_page_not_found', username=username)
         return
 
-    if not is_not_participating(r.content):
+    if not is_not_participating(html):
         log.warning(f'{username} never played CTF all the day.')
         return
 
-    pseudo = extract_pseudo(r.content)
-    num_success, num_try = extract_summary(r.content)
+    pseudo = extract_pseudo(html)
+    num_success, num_try = extract_summary(html)
     description = f'{num_success} machine(s) compromise(s) en {num_try} tentatives'
     tp_function = partial(get_ctf_page, username)
     nb_ctf_pages = 2  # might need to be changed in some months/years

--- a/worker/worker/redis_interface/details.py
+++ b/worker/worker/redis_interface/details.py
@@ -2,6 +2,7 @@ import json
 
 from worker import log
 from worker.constants import URL
+from worker.http_client import http_get
 from worker.parser.details import extract_score, extract_nb_challenges_solved, extract_ranking, \
     extract_ranking_category, extract_challenges
 from worker.parser.profile import extract_pseudo
@@ -9,17 +10,17 @@ from worker.redis_interface import session, redis_app
 
 
 def set_user_details(username):
-    r = session.get(URL + username + '?inc=score')
-    if r.status_code != 200:
-        log.warning(f'HTTP {r.status_code} for username {username}.')
+    html = http_get(URL + username + '?inc=score')
+    if html is None:
+        log.warning(f'could_not_get_user_details', username=username)
         return
 
-    pseudo = extract_pseudo(r.content)
-    score = extract_score(r.content)
-    nb_challenges_solved, nb_challenges_tot = extract_nb_challenges_solved(r.content)
-    ranking, ranking_tot = extract_ranking(r.content)
-    ranking_category = extract_ranking_category(r.content)
-    categories = extract_challenges(r.content)
+    pseudo = extract_pseudo(html)
+    score = extract_score(html)
+    nb_challenges_solved, nb_challenges_tot = extract_nb_challenges_solved(html)
+    ranking, ranking_tot = extract_ranking(html)
+    ranking_category = extract_ranking_category(html)
+    categories = extract_challenges(html)
 
     response = [{
         'pseudo': pseudo,

--- a/worker/worker/redis_interface/profile.py
+++ b/worker/worker/redis_interface/profile.py
@@ -2,18 +2,19 @@ import json
 
 from worker import log
 from worker.constants import URL
+from worker.http_client import http_get
 from worker.parser.profile import extract_pseudo, extract_score
 from worker.redis_interface import session, redis_app
 
 
 def set_user_profile(username):
-    r = session.get(URL + username)
-    if r.status_code != 200:
-        log.warning(f'HTTP {r.status_code} for user {username}')
+    html = http_get(URL + username)
+    if html is None:
+        log.warning(f'user_profile_not_found', username=username)
         return
 
-    pseudo = extract_pseudo(r.content)
-    score = extract_score(r.content)
+    pseudo = extract_pseudo(html)
+    score = extract_score(html)
     response = [{
         'pseudo': pseudo,
         'score': score,

--- a/worker/worker/redis_interface/stats.py
+++ b/worker/worker/redis_interface/stats.py
@@ -2,19 +2,20 @@ import json
 
 from worker import log
 from worker.constants import URL
+from worker.http_client import http_get
 from worker.parser.profile import extract_pseudo
 from worker.parser.stats import extract_stats
-from worker.redis_interface import session, redis_app
+from worker.redis_interface import redis_app
 
 
 def set_user_stats(username):
-    r = session.get(URL + username + '?inc=statistiques')
-    if r.status_code != 200:
-        log.warning(f'HTTP {r.status_code} for username {username}.')
+    html = http_get(URL + username + '?inc=statistiques')
+    if html is None:
+        log.warning(f'could_not_get_user_stats', username=username)
         return
 
-    pseudo = extract_pseudo(r.content)
-    solved_challenges = extract_stats(r.content)
+    pseudo = extract_pseudo(html)
+    solved_challenges = extract_stats(html)
 
     response = {
         'pseudo': pseudo,


### PR DESCRIPTION
Dans le code, on utilise le `content` de `session.get()` partout. Au lieu d'à chaque fois faire 
```python
r = session.get(url)
if r.status_code != 200:
    log.warning('un message d'erreur super long')
    return
```

On peut abstraire l'appel à requests dans une fonction bien à part pour profiter de logs consistent et de pas avoir à se faire chier avec des status_code partout.

Ca permet de faire en sorte que si un jour on veuille passer à une autre lib que requests, on puisse facilement. (ou alors par exemple modifier la fonction get pour qu'elle passe par des proxy ;) )
Et puis les fonctions du type `get_solution_contributions` devraient pas avoir à se soucier de 'comment' on fetch les pages HTML, elles veulent juste le résultat.

Du coup j'ai tout mis dans une fonction que on importe partout. (c'est un peu la couche 'interface adapter' de la clean archi).

Cette fonction retourne le HTML ou None si on reçoit un 404. Toute autre erreur HTTP est inattendue et donc renvoie une exception